### PR TITLE
Fix issue with SourceBuffer taking the entire line for single line statements instead of substring ending at LastCol

### DIFF
--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/util/SourceBuffer.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/util/SourceBuffer.java
@@ -142,7 +142,11 @@ public class SourceBuffer {
             }
           }
         } else {
-          lines.add(currentLine.substring(Math.max(p.getFirstCol(), 0)));
+          if (p.getLastLine() > p.getFirstLine()) {
+            lines.add(currentLine.substring(Math.max(p.getFirstCol(), 0)));
+          } else {
+            lines.add(currentLine.substring(Math.max(p.getFirstCol(), 0), p.getLastCol() + 1));
+          }
           startColumn = p.getFirstCol();
         }
 

--- a/com.ibm.wala.cast/src/test/java/com/ibm/wala/cast/test/TestSourceBuffer.java
+++ b/com.ibm.wala.cast/src/test/java/com/ibm/wala/cast/test/TestSourceBuffer.java
@@ -131,27 +131,33 @@ public class TestSourceBuffer {
   }
   
   @Test
-  public void testSingleLineNoPeriod() throws IOException {
-    // position of "IF WS-INPUT = 0" [3:12] -> [3:26] (1-base indexing)
-    Position position = mockPosition(3, 12, 3, 26, -1, -1);
+  public void testSingleLineOmitPeriod() throws IOException {
+    // position of "ACCEPT WS-INPUT" [2:12] -> [2:26] (1-base indexing)
+    Position position = mockPosition(2, 12, 2, 26, -1, -1);
 
     String sourceBufferString = new SourceBuffer(position).toString();
-    testEqualString(sourceBufferString, "IF WS-INPUT = 0");
+    testEqualString(sourceBufferString, "ACCEPT WS-INPUT");
   }
 
   @Test
-  public void testMultiLineNoPeriod() throws IOException {
+  public void testMultiLineOmitPeriod() throws IOException {
     /* position of "
        IF WS-INPUT = 0
-       GO TO IS-ZERO" [3:12] -> [4:24] (1-base indexing)
+       GO TO IS-ZERO
+       ELSE
+       GO TO END-PROGRAM" [3:12] -> [6:28] (1-base indexing)
     */
-    Position position = mockPosition(3, 12, 4, 24, -1, -1);
+    Position position = mockPosition(3, 12, 6, 28, -1, -1);
 
     String sourceBufferString = new SourceBuffer(position).toString();
     testEqualString(
         sourceBufferString,
         "IF WS-INPUT = 0\n"
             + INDENT
-            + "GO TO IS-ZERO");
+            + "GO TO IS-ZERO\n"
+            + INDENT
+            + "ELSE\n"
+            + INDENT
+            + "GO TO END-PROGRAM");
   }
 }

--- a/com.ibm.wala.cast/src/test/java/com/ibm/wala/cast/test/TestSourceBuffer.java
+++ b/com.ibm.wala.cast/src/test/java/com/ibm/wala/cast/test/TestSourceBuffer.java
@@ -10,94 +10,100 @@
  */
 package com.ibm.wala.cast.test;
 
+import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
+import com.ibm.wala.cast.util.SourceBuffer;
+import com.ibm.wala.classLoader.IMethod.SourcePosition;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URL;
-
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
-import com.ibm.wala.cast.util.SourceBuffer;
-import com.ibm.wala.classLoader.IMethod.SourcePosition;
-
 public class TestSourceBuffer {
-  final static String INDENT = "           "; // whitespaces in column 1:11
+  static final String INDENT = "           "; // whitespaces in column 1:11
 
   private URL getSourceUrl() throws MalformedURLException {
-    File testSourceBufferCbl = 
-      new File(getClass().getClassLoader().getResource("test_sourcebuffer.cbl").getFile());
+    File testSourceBufferCbl =
+        new File(getClass().getClassLoader().getResource("test_sourcebuffer.cbl").getFile());
     return new URL("file:" + testSourceBufferCbl.getAbsolutePath());
   }
 
-  private Position mockPosition(final int firstLine, final int firstCol, final int lastLine,
-    final int lastCol, final int firstOffset, final int lastOffset) throws MalformedURLException {
+  private Position mockPosition(
+      final int firstLine,
+      final int firstCol,
+      final int lastLine,
+      final int lastCol,
+      final int firstOffset,
+      final int lastOffset)
+      throws MalformedURLException {
     URL src = getSourceUrl();
-    
-    Position position = new Position() {
 
-			@Override
-			public int getFirstLine() {
-				return firstLine;
-			}
+    Position position =
+        new Position() {
 
-			@Override
-			public int getLastLine() {
-				return lastLine;
-			}
+          @Override
+          public int getFirstLine() {
+            return firstLine;
+          }
 
-			@Override
-			public int getFirstCol() {
-				return firstCol - 1;  // 0-base indexing
-			}
+          @Override
+          public int getLastLine() {
+            return lastLine;
+          }
 
-			@Override
-			public int getLastCol() {
-				return lastCol - 1; // 0-base
-			}
+          @Override
+          public int getFirstCol() {
+            return firstCol - 1; // 0-base indexing
+          }
 
-			@Override
-			public int getFirstOffset() {
-        return firstOffset;
-			}
+          @Override
+          public int getLastCol() {
+            return lastCol - 1; // 0-base
+          }
 
-			@Override
-			public int getLastOffset() {
-        return lastOffset;
-			}
+          @Override
+          public int getFirstOffset() {
+            return firstOffset;
+          }
 
-			@Override
-			public int compareTo(SourcePosition o) {
-				return -1;
-			}
+          @Override
+          public int getLastOffset() {
+            return lastOffset;
+          }
 
-			@Override
-			public URL getURL() {
-				return src;
-			}
+          @Override
+          public int compareTo(SourcePosition o) {
+            return -1;
+          }
 
-			@Override
-			public Reader getReader() throws IOException {
-				return new InputStreamReader(src.openStream());
-			}
-    };
+          @Override
+          public URL getURL() {
+            return src;
+          }
+
+          @Override
+          public Reader getReader() throws IOException {
+            return new InputStreamReader(src.openStream());
+          }
+        };
 
     System.err.println("position: " + position);
     return position;
   }
 
   private static void testEqualString(final String actual, final String expected) {
-    Assert.assertTrue("expected '" + expected + "' but got '" + actual + "'", actual.equals(expected));
+    Assert.assertTrue(
+        "expected '" + expected + "' but got '" + actual + "'", actual.equals(expected));
   }
 
   @Test
   public void testSingleLineNoOffset() throws IOException {
     // position of "ACCEPT WS-INPUT." [2:12] -> [2:27] (1-base indexing)
     Position position = mockPosition(2, 12, 2, 27, -1, -1);
-      
+
     String sourceBufferString = new SourceBuffer(position).toString();
     testEqualString(sourceBufferString, "ACCEPT WS-INPUT.");
   }
@@ -105,19 +111,47 @@ public class TestSourceBuffer {
   @Test
   public void testMultiLineNoOffset() throws IOException {
     /* position of "
-        IF WS-INPUT = 0
-        GO TO IS-ZERO
-        ELSE
-        GO TO END-PROGRAM." [3:12] -> [6:29] (1-base indexing)
-     */
+       IF WS-INPUT = 0
+       GO TO IS-ZERO
+       ELSE
+       GO TO END-PROGRAM." [3:12] -> [6:29] (1-base indexing)
+    */
     Position position = mockPosition(3, 12, 6, 29, -1, -1);
-      
+
     String sourceBufferString = new SourceBuffer(position).toString();
-    testEqualString(sourceBufferString, "IF WS-INPUT = 0\n" + 
-      INDENT + "GO TO IS-ZERO\n" + 
-      INDENT + "ELSE\n" + 
-      INDENT + "GO TO END-PROGRAM.");
-    
+    testEqualString(
+        sourceBufferString,
+        "IF WS-INPUT = 0\n"
+            + INDENT
+            + "GO TO IS-ZERO\n"
+            + INDENT
+            + "ELSE\n"
+            + INDENT
+            + "GO TO END-PROGRAM.");
+  }
+  
+  @Test
+  public void testSingleLineNoPeriod() throws IOException {
+    // position of "IF WS-INPUT = 0" [3:12] -> [3:26] (1-base indexing)
+    Position position = mockPosition(3, 12, 3, 26, -1, -1);
+
+    String sourceBufferString = new SourceBuffer(position).toString();
+    testEqualString(sourceBufferString, "IF WS-INPUT = 0");
   }
 
+  @Test
+  public void testMultiLineNoPeriod() throws IOException {
+    /* position of "
+       IF WS-INPUT = 0
+       GO TO IS-ZERO" [3:12] -> [4:24] (1-base indexing)
+    */
+    Position position = mockPosition(3, 12, 4, 24, -1, -1);
+
+    String sourceBufferString = new SourceBuffer(position).toString();
+    testEqualString(
+        sourceBufferString,
+        "IF WS-INPUT = 0\n"
+            + INDENT
+            + "GO TO IS-ZERO");
+  }
 }


### PR DESCRIPTION
Previously the first line of a statement in SourceBuffer is the substring from `max(firstCol, 0)` up to the end of the line. This is fine for multi-line statements, but for single line statements, SourceBuffer does not capture the string within the given position range. This PR fixes this issue by putting `lastCol + 1` as the endIndex of `substring()` and adds two tests for verification