### PR TITLE
Print continue and improve break in notTaken

### DIFF
--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1663,7 +1663,7 @@ public abstract class ToSource {
         @Override
         public void visitGoto(SSAGotoInstruction inst) {
           ISSABasicBlock bb = cfg.getBlockForInstruction(inst.iIndex());
-          if (loopHeaders.containsAll(cfg.getNormalSuccessors(bb))) {
+          if (loopHeaders.containsAll(cfg.getNormalSuccessors(bb)) && inLoop(bb)) {
             node = ast.makeNode(CAstNode.CONTINUE);
           } else if (loopExits.containsAll(cfg.getNormalSuccessors(bb)) && inLoop(bb)) {
             node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.BREAK));
@@ -2898,6 +2898,12 @@ public abstract class ToSource {
           {
             indent();
             out.println("break;");
+            return true;
+          }
+        case CAstNode.CONTINUE:
+          {
+            indent();
+            out.println("continue;");
             return true;
           }
         default:

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -2163,14 +2163,14 @@ public abstract class ToSource {
             List<CAstNode> notTakenBlock = handleBlock(notTakenChunks, fr, false);
 
             // For the case where there's a need to jump out of the loop, break should be added
-            // if notTakenBlock is empty (or have not have goto at the last?), add break
+            // if notTakenBlock is selected (or have goto at the last?), add break
             // if takenBlock is null, add break
             // if takenBlock is not null, add break (or have goto at last?)
             if (loopBreakers.contains(branchBB)
                 && !loopControls.containsKey(branchBB)
                 && !loopHeaders.contains(branchBB)) {
               if (loopExits.contains(notTaken)) {
-                if (notTakenBlock.size() < 1) notTakenBlock.add(ast.makeNode(CAstNode.BREAK));
+                notTakenBlock.add(ast.makeNode(CAstNode.BREAK));
               } else {
                 if (takenBlock == null)
                   takenBlock = Collections.singletonList(ast.makeNode(CAstNode.BREAK));


### PR DESCRIPTION
Changes:
1) Print continue in java file
2) Skip creating continue node if the block is not part of the loop
3) Add break into notTaken block (remove the condition)

With the change, 3 samples will be translated correctly and no impact to others (regression test passed). Result can be found https://github.ibm.com/EZSource/code-transformer/pull/35