### PR TITLE
Remove Duplicate GoTos from inlined Blocks

### DIFF
--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -2272,7 +2272,15 @@ public abstract class ToSource {
               handleInsts(
                   loopChunks,
                   lr,
-                  x -> x.iterator().next() instanceof SSAGotoInstruction,
+                  x -> {
+                    SSAInstruction next = x.iterator().next();
+                    return (next instanceof SSAGotoInstruction) &&
+                            // Check if a GoTo's target is contained in the loop chunks being processed.
+                            // If it is, the GoTo should not be included in the output.
+                            loopChunks.stream().noneMatch(loi ->
+                                    loi.stream().noneMatch(i ->
+                                            i.iIndex() == ((SSAGotoInstruction)next).getTarget()));
+                  },
                   extraHeaderCode);
 
           List<CAstNode> block = new LinkedList<>();


### PR DESCRIPTION
### Summary

- The code as it stands may create infinite loops, but I _can_ work around this in my client code.
- This change doesn't cause any test failures, but isn't ideal (for the reasons described below). We probably just need more test cases.
- A better change is possible, but would require re-working these handleBlock and handleInstruction methods.

@juliandolby you're much more familiar with this code. How would your recommend I proceed?

### The Problem

Previously, ToSource's handleBlock method would include all gotos from loopChunks--including those which referenced the newly inlined instructions. This leads to a problem described by the following pseudo-code:

```
Block-1:
1-0  if test
1-2    goto 2-0
1-3  fi
     ...

Block-2:
2-0  do-other-stuff
``` 

This code would be inlined as follows:

```
Block-1:
1-0  if test
2-0    do-other-stuff
1-2    goto 2-0
1-3  fi
     ...
```

### An Easy Partial Solution

Creating an infinite loop isn't ideal, but neither is the solution in this PR. Presumably this would create an issue with the following code which actually should loop:

```
Block-1:
1-0  if test
1-2    goto 2-0
1-3  fi
     ...

Block-2:
2-0  if another-test
2-1    goto 2-0
2-2  fi
```

Creating:

```
Block-1:
1-0  if test
2-0    if another-test
2-1      !!!
2-2    fi
1-3  fi
```

### A Complete Solution

What I believe we need is to check whether the target is contained in `normalStuff`. However, CAstNodes don't know iindex of the SSA instruction they are derived from, so this would require re-thinking how the instructions are partitioned.
