### PR TITLE
Remove leading negation from CAst generated by SSAConditionalInstructions

### DIFF
--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1961,7 +1961,7 @@ public abstract class ToSource {
         }
 
         /**
-         * Remove redundant negation from test node and single branch.
+         * Remove redundant negation from test node.
          * <ul>
          * <li>Even or zero negation count: all negation can be removed.</li>
          * <li>Odd count: remove negation and flip branches.</li>
@@ -2007,9 +2007,13 @@ public abstract class ToSource {
         }
 
         /**
-         * Remove redundant negation from predicate node and single branch.
-         * Even or zero negation count: all negation can be removed.
-         * Odd count: must remove all but one.
+         * Remove redundant negation from test node.
+         * <ul>
+         * <li>Even or zero negation count: all negation can be removed.</li>
+         * <li>Odd count: remove negation and flip branches.</li>
+         * </ul>
+         * @param pred The node from which negation should be removed.
+         * @return The input node, with pairs of leading negation removed.
          */
         private CAstNode stableRemoveLeadingNegation(CAstNode pred) {
           Pair<Integer,CAstNode> countAndPred = countAndRemoveLeadingNegation(pred);

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1955,19 +1955,21 @@ public abstract class ToSource {
           return test;
         }
 
-        /**
-         * Remove redundant negation from test node and single branch.
-         * Even or zero negation count: all negation can be removed.
-         * Odd count: must remove all but one.
-         */
+
         private CAstNode makeIfStmt(CAstNode test, CAstNode thenBranch) {
           return ast.makeNode(CAstNode.IF_STMT, stableRemoveLeadingNegation(test), thenBranch);
         }
 
         /**
          * Remove redundant negation from test node and single branch.
-         * Even or zero negation count: all negation can be removed.
-         * Odd count: remove negation and flip branches.
+         * <ul>
+         * <li>Even or zero negation count: all negation can be removed.</li>
+         * <li>Odd count: remove negation and flip branches.</li>
+         * </ul>
+         * @param test The test node for the if-stmt to be created. May contain leading negation.
+         * @param thenBranch The 'true' branch of the if-stmt. May be flipped with the else branch if negation count is odd.
+         * @param elseBranch The 'false' branch of the if-stmt. May be flipped with the then branch if negation count is odd.
+         * @return A CAstNode of type IF_STMT equivalent to (if test thenBranch elseBranch), with leading negation removed from test and possible then/else branches swapped.
          */
         private CAstNode makeIfStmt(CAstNode test, CAstNode thenBranch, CAstNode elseBranch) {
           Pair<Integer,CAstNode> countAndTest = countAndRemoveLeadingNegation(test);
@@ -1978,6 +1980,11 @@ public abstract class ToSource {
           }
         }
 
+        /**
+         * Counts leading negation and removes it from the input node. Then returns a pair with this information.
+         * @param n The input node.
+         * @return A pair with first element count, and second element n, but with all leading negation removed.
+         */
         private Pair<Integer,CAstNode> countAndRemoveLeadingNegation(CAstNode n) {
           int count = 0;
           CAstNode tmp = n;
@@ -1999,6 +2006,11 @@ public abstract class ToSource {
                   n.getChild(0) == CAstOperator.OP_NOT;
         }
 
+        /**
+         * Remove redundant negation from predicate node and single branch.
+         * Even or zero negation count: all negation can be removed.
+         * Odd count: must remove all but one.
+         */
         private CAstNode stableRemoveLeadingNegation(CAstNode pred) {
           Pair<Integer,CAstNode> countAndPred = countAndRemoveLeadingNegation(pred);
           if (countAndPred.fst % 2 == 0) {


### PR DESCRIPTION
This change simplifies processing of the produced CAst by removing leading negation from generated conditions. In many cases, the generated CAst contained multiple levels of leading Unary-Nots which can be eliminated. The transformation assumes that pairs of Unary-Nots can be removed without changing the semantics of the generated CAst.

As such `(if (Not (Not cond)) then else)` is equivalent to `(if cond then else)`. And, `(if (Not cond) then else)` is equivalent to `(if cond else then)`.

SSAConditionalInstructions are also examined in loop generation. This change applies the same transformations to loop conditions as well. Because there is nothing to swap, loop conditions are transformed to remove pairs of negation, but may keep exactly one leading Unary-Not. This is analogous to single-branch if-stmts. In both single-branch if-stmts and loops, no attempt is made to invert the condition of binary expressions.

@juliandolby please review and merge when convenient.