### PR TITLE
Add work-around for local builds after #18

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -83,11 +83,17 @@ artifactory {
         repository {
 			if (isSnapshot) {
 				repoKey = 'zeus-ez-libs-snapshot-local'
-			} else { 
+			} else {
 				repoKey = 'zeus-ez-libs-release-local'
 			}
-            username = mavenUsername
-            password = mavenPassword
+            if (hasProperty("mavenUsername") && hasProperty("mavenPassword")) {
+                username = mavenUsername
+                password = mavenPassword
+            } else {
+                // Avoid error due to missing definition on local builds
+                username = "notarealusername"
+                password = "notarealpassword"
+            }
         }
 
         defaults {


### PR DESCRIPTION
After #18 I see the following error when building wala on my local machine.

```
Script '...WALA/gradle-mvn-push.gradle' line: 89

* What went wrong:
A problem occurred evaluating script.
> Could not get unknown property 'mavenUsername' for object of type org.jfrog.gradle.plugin.artifactory.dsl.PublisherConfig$Repository.

```

The variables `mavenUsername` and `mavenPassword` are not defined in my local environment.

Please confirm that this change doesn't break the server-side changes @alecsis1.