### PR TITLE
Only generate continue for the case of more than one loop part

### DIFF
--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
@@ -110,4 +110,18 @@ public class Loop {
     assert (parts.size() > 0);
     return loopExits;
   }
+
+  /**
+   * When there are more than one loop part, the last block will be the one for the loop instead of
+   * the loop part
+   *
+   * @return The last block of the loop
+   */
+  public boolean isLastBlock(ISSABasicBlock block) {
+    assert (parts.size() > 0);
+    return allBlocks.stream()
+        .max(Comparator.comparing(ISSABasicBlock::getNumber))
+        .get()
+        .equals(block);
+  }
 }

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1581,7 +1581,8 @@ public abstract class ToSource {
           Loop loop = LoopHelper.getLoopByInstruction(cfg, inst, loops);
           if (loop != null
               && loop.getLoopHeader().equals(cfg.getNormalSuccessors(bb).iterator().next())) {
-            node = ast.makeNode(CAstNode.CONTINUE);
+            // seems we dont need to generate CONTINUE
+            //node = ast.makeNode(CAstNode.CONTINUE);
           } else if (loop != null && loop.getLoopExits().containsAll(cfg.getNormalSuccessors(bb))) {
             node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.BREAK));
           } else {

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1580,9 +1580,10 @@ public abstract class ToSource {
           ISSABasicBlock bb = cfg.getBlockForInstruction(inst.iIndex());
           Loop loop = LoopHelper.getLoopByInstruction(cfg, inst, loops);
           if (loop != null
-              && loop.getLoopHeader().equals(cfg.getNormalSuccessors(bb).iterator().next())) {
-            // seems we dont need to generate CONTINUE
-            //node = ast.makeNode(CAstNode.CONTINUE);
+              && loop.getLoopHeader().equals(cfg.getNormalSuccessors(bb).iterator().next())
+              && !loop.isLastBlock(bb)) {
+            // if there are more than one loop part, only last one should not generate CONTINUE
+            node = ast.makeNode(CAstNode.CONTINUE);
           } else if (loop != null && loop.getLoopExits().containsAll(cfg.getNormalSuccessors(bb))) {
             node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.BREAK));
           } else {


### PR DESCRIPTION
When there are only one loop part, there's no need to generate continue.
When there are only one loop part, only the last block of the whole loop should not generate continue, but for other `end` of the loop part should generate continue.
Tested C2J all works well