### PR TITLE
Track source position info in CAst Generation

### DIFF
--- a/com.ibm.wala.cast.java/src/main/java/com/ibm/wala/cast/java/toSource/ToSourceFromJava.java
+++ b/com.ibm.wala.cast.java/src/main/java/com/ibm/wala/cast/java/toSource/ToSourceFromJava.java
@@ -66,7 +66,7 @@ public class ToSourceFromJava extends ToSource {
 
     @Override
     protected ToCAst makeToCAst(List<SSAInstruction> c) {
-      return new ToCAst(c, new CodeGenerationContext(types, mergePhis, false)) {
+      return new ToCAst(c, new CodeGenerationContext(types, mergePhis, false, super.positionRecorder)) {
 
         class JavaVisitor
             extends com.ibm.wala.cast.ir.toSource.ToSource.RegionTreeNode.ToCAst.Visitor


### PR DESCRIPTION
This PR modifies `toSource` and inner classes to store position information for each generated `CAstNode`.

To accomplish this change, a new method `toCAstEntity: List<Loop> -> CAstEntity` is created to replace `toCAst: List<Loop> -> CAstNode`. The method `getAst: () -> CAstNode` can be used on the entity to get the root `CAstNode`. To store position information, new `CAstPositionRecorder` is created in each `RegionTreeNode` and passed to the `AstPreInstructionVisitor` via a `CodeGenerationContext` object.

In the visitor, the `CAstSourcePositionRecorder` is updated using the position information stored in the IR's `AstMethod` object. At the point of `CAstNode` creation, the index can be used to link the position information with the new CAstNode, by using the instruction-index to look up the position returned by the AstMethod's `getPosition: int -> Position` method. This position object is then stored in the position-recorder, and later available (through the CAstEntity) to source code generation.

### Testing

~~In progress~~

Please review when convenient @juliandolby.