### PR TITLE
Update empty map & list in toCAstEntitiy to return java-8 compatible methods

### DIFF
--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1397,7 +1397,7 @@ public abstract class ToSource {
 
         @Override
         public Map<CAstNode, Collection<CAstEntity>> getAllScopedEntities() {
-          return Map.of();
+          return Collections.emptyMap();
         }
 
         @Override
@@ -1442,7 +1442,7 @@ public abstract class ToSource {
 
         @Override
         public Collection<CAstQualifier> getQualifiers() {
-          return List.of();
+          return Collections.emptyList();
         }
 
         @Override
@@ -1452,7 +1452,7 @@ public abstract class ToSource {
 
         @Override
         public Collection<CAstAnnotation> getAnnotations() {
-          return List.of();
+          return Collections.emptyList();
         }
       };
     }


### PR DESCRIPTION
Updates the `List.of` and `Map.of` calls from #29 to use java-8 friendly methods.

Please review and merge when convenient @juliandolby.