### PR TITLE
Fix issue related with perform-inline-loop-nest-nest

### DIFF
--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -943,18 +943,23 @@ public abstract class ToSource {
 
       // figure out nested loops
       // handle nested loop
-      loops
-          .values()
+      loops.keySet().stream()
+          .sorted(
+              (a, b) -> {
+                return b.getNumber() - a.getNumber();
+              })
           .forEach(
-              loop -> {
+              loopHeader -> {
                 for (Loop parent : loops.values()) {
 
                   // check if loop header belongs to a loop
-                  if (parent != loop
-                      && parent.getAllBlocks().contains(loop.getLoopHeader())
-                      && parent.getAllBlocks().containsAll(loop.getLoopBreakers())) {
+                  if (parent != loops.get(loopHeader)
+                      && parent.getAllBlocks().contains(loopHeader)
+                      && parent
+                          .getAllBlocks()
+                          .containsAll(loops.get(loopHeader).getLoopBreakers())) {
                     // this is nested loop
-                    parent.addLoopNested(loop);
+                    parent.addLoopNested(loops.get(loopHeader));
                   }
                 }
               });


### PR DESCRIPTION
As mentioned in slack channel, perform-inline-loop-nest-nest.cbl can be translated successfully. But sometimes it's while-true loop and sometimes it's for-loop.

By debugging, the issue is caused by nested loop (3 layers): loop1, loop2 and loop3, let's say loop1 is the inner loop, loop3 is the outer loop while loop2 is the middle loop.
When loop2 is found as nested loop of loop3, before the relationship of loop1 is nested in loop2, then loop3's all blocks will not contain the ones in loop1. Thus loop3 will have more than one loop breakers, so it'll be while-true loop.

This change will sort loops by their loop header desc. So that the inner loop relationship will always be found before outer loops.