### PR TITLE
Support nested loops where they share loop control

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
@@ -160,4 +160,8 @@ public class Loop {
                 .collect(Collectors.toList())
                 .toArray());
   }
+
+  public boolean hasNestedLoop() {
+    return nestedLoops.size() > 0;
+  }
 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
@@ -161,6 +161,10 @@ public class Loop {
                 .toArray());
   }
 
+  public boolean containsNestedLoop() {
+    return !nestedLoops.isEmpty();
+  }
+
   public boolean containsNestedLoop(Loop loop) {
     return nestedLoops.contains(loop);
   }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
@@ -161,7 +161,7 @@ public class Loop {
                 .toArray());
   }
 
-  public boolean hasNestedLoop() {
-    return nestedLoops.size() > 0;
+  public boolean containsNestedLoop(Loop loop) {
+    return nestedLoops.contains(loop);
   }
 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -207,6 +207,7 @@ public class LoopHelper {
 
   /**
    * Find out the loop that contains the instruction
+   * It'll try to find the inner loop first and then outer loop (backwards)
    *
    * @param cfg The control flow graph
    * @param instruction The instruction to be used to look for a loop
@@ -269,6 +270,7 @@ public class LoopHelper {
     return result.isPresent() ? result.get() : null;
   }
 
+  // check if the assignment is in both inner and outer loop
   public static boolean containsInNestedLoop(
       Loop loop, Map<ISSABasicBlock, Loop> loops, ISSABasicBlock assignmentBlock) {
     return loop.containsNestedLoop()
@@ -279,6 +281,7 @@ public class LoopHelper {
                 });
   }
 
+  // check if the given loop has nested loops and one of the nested loops has the same loop control as the outer one
   public static boolean hasInnerLoopShareLoopControl(Loop loop, Map<ISSABasicBlock, Loop> loops) {
     return loops.values().stream()
         .anyMatch(
@@ -369,6 +372,7 @@ public class LoopHelper {
 
   /**
    * Check if the given instruction is part of loop control
+   * It will check inner loop first
    *
    * @param cfg The control flow graph
    * @param inst The instruction to be used to check

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -279,6 +279,14 @@ public class LoopHelper {
                 });
   }
 
+  public static boolean hasInnerLoopShareLoopControl(Loop loop, Map<ISSABasicBlock, Loop> loops) {
+    return loops.values().stream()
+        .anyMatch(
+            c -> {
+              return loop.containsNestedLoop(c) && loop.getLoopControl().equals(c.getLoopControl());
+            });
+  }
+
   /**
    * Find out if the given chunk is in the loop and before the conditional branch of the loop
    * control

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1537,7 +1537,6 @@ public abstract class ToSource {
               .filter(inst -> (inst instanceof SSAConditionalBranchInstruction))
               .findFirst()
               .get();
-      //      condChunk.remove(instruction);
 
       CAstNode test;
       if (condChunkWithoutConditional.size() > 0) {
@@ -1857,11 +1856,12 @@ public abstract class ToSource {
                           loopChunks,
                           decls,
                           currentLoops,
-                          new ArrayList<>()); // TODO: lisa check last param
+                          new ArrayList<>());
                   elts.addAll(stuff.fst.getChildren());
                   loopChunks.clear();
                 }
 
+                // For the call comes from toCAst, the body should always be called, otherwise, skip loop control
                 if (!(verifyConditional
                     && (LoopHelper.isConditional(chunks.get(chunks.size() - 1))
                         && chunkInsts.equals(chunks.get(chunks.size() - 1))))) {

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1651,8 +1651,6 @@ public abstract class ToSource {
         test = ast.makeNode(CAstNode.UNARY_EXPR, CAstOperator.OP_NOT, test);
       }
 
-      CAstNode originalTest = test;
-
       List<CAstNode> loopBodyNodes = new ArrayList<>();
       CAstNode bodyNode = null;
       if (elts != null && elts.size() > 0) {
@@ -1832,8 +1830,7 @@ public abstract class ToSource {
               bodyNode,
               // reuse LOOP type but add third child as a boolean to tell if it's a do while
               // loop
-              ast.makeConstant(LoopType.DOWHILE.equals(loopType)),
-              originalTest);
+              ast.makeConstant(LoopType.DOWHILE.equals(loopType)));
 
       ISSABasicBlock next =
           cfg.getBlockForInstruction(((SSAConditionalBranchInstruction) instruction).getTarget());
@@ -1926,17 +1923,6 @@ public abstract class ToSource {
 
       Pair<CAstNode, List<CAstNode>> stuff =
           toLoopCAst(loopChunks, decls, parentLoops, new ArrayList<>());
-
-      List<CAstNode> body = stuff.fst.getChildren();
-
-      // TODO: check if parent loop and current loop, loop control is the same, if yes, a if-else
-      // should be added
-      if (body.size() > 0
-          && body.get(0).getKind() == CAstNode.BLOCK_STMT
-          && body.get(0).getChildCount() > 0
-          && body.get(0).getChild(0).getKind() == CAstNode.LOOP) {
-        System.out.println("here");
-      }
       elts.addAll(stuff.fst.getChildren());
       loopChunks.clear();
     }


### PR DESCRIPTION
This is one of the case of feature 18: GO TO beginning of same paragraph (loop) inside a conditional in an inline PERFORM
The IR will be something like
  Outer loop header -> Inner loop header -> Loop control for both -> loop body

So that a "loop" should be created before outer loop visits it's loop control.
And the loop control should be visited twice: one for inner loop to generate correct AST. One for the outer loop to generate something like
  if test then break

Tested with code transformer.