### PR TITLE
Improve Feature17

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
@@ -6,6 +6,7 @@ import com.ibm.wala.cast.tree.impl.CAstImpl;
 import com.ibm.wala.cast.tree.impl.CAstOperator;
 import com.ibm.wala.cast.util.CAstPattern;
 import com.ibm.wala.util.collections.Pair;
+import java.util.List;
 
 /** The helper class for some methods of loop */
 public class CAstHelper {
@@ -132,5 +133,23 @@ public class CAstHelper {
   public static boolean hasVarAssigned(CAstNode node, String var) {
     CAstPattern jumpAssign = CAstPattern.parse("ASSIGN(VAR(\"" + var + "\"),**)");
     return !CAstPattern.findAll(jumpAssign, node).isEmpty();
+  }
+
+  public static boolean containsOnlyGotoAndBreak(List<CAstNode> nodes) {
+    boolean result = true;
+    if (nodes.isEmpty()) return result;
+
+    for (CAstNode nn : nodes) {
+      if (nn.getKind() == CAstNode.GOTO) continue;
+      if (nn.getKind() == CAstNode.BREAK) continue;
+      if (nn.getKind() == CAstNode.BLOCK_STMT) {
+        result = containsOnlyGotoAndBreak(nn.getChildren());
+        if (!result) break;
+      }
+      result = false;
+      break;
+    }
+
+    return result;
   }
 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
@@ -145,7 +145,9 @@ public class CAstHelper {
       if (nn.getKind() == CAstNode.BLOCK_STMT) {
         result = containsOnlyGotoAndBreak(nn.getChildren());
         if (!result) break;
+        else continue;
       }
+      // for other cases, return false
       result = false;
       break;
     }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
@@ -6,6 +6,7 @@ import com.ibm.wala.util.collections.Pair;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -175,5 +176,24 @@ public class Loop {
         .map(pair -> pair.fst)
         .findFirst()
         .get();
+  }
+
+  public boolean isLastBlockOfMiddlePart(ISSABasicBlock lastBlock) {
+    if (parts.size() > 1) {
+      List<ISSABasicBlock> allLastBlocks =
+          parts.stream()
+              .map(
+                  pp ->
+                      pp.getAllBlocks().stream()
+                          .max(Comparator.comparing(ISSABasicBlock::getNumber))
+                          .get())
+              .collect(Collectors.toList());
+      return allLastBlocks.contains(lastBlock)
+          && !allLastBlocks.stream()
+              .max(Comparator.comparing(ISSABasicBlock::getNumber))
+              .get()
+              .equals(lastBlock);
+    }
+    return false;
   }
 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
@@ -188,11 +188,11 @@ public class Loop {
                           .max(Comparator.comparing(ISSABasicBlock::getNumber))
                           .get())
               .collect(Collectors.toList());
-      return allLastBlocks.contains(lastBlock)
-          && !allLastBlocks.stream()
-              .max(Comparator.comparing(ISSABasicBlock::getNumber))
-              .get()
-              .equals(lastBlock);
+      return allLastBlocks.contains(lastBlock);
+      //          && !allLastBlocks.stream()
+      //              .max(Comparator.comparing(ISSABasicBlock::getNumber))
+      //              .get()
+      //              .equals(lastBlock);
     }
     return false;
   }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -458,6 +458,9 @@ public class LoopHelper {
     // value: the loops been jumped, not including the inner loop and outer loop
     HashMap<ISSABasicBlock, List<Loop>> jumpToTop = HashMapFactory.make();
     // collect loop break and the jumps, key: loopBreaker,
+    // value: the loop that has middle loop part which will go to header of the parent
+    HashMap<ISSABasicBlock, List<Loop>> returnToParentHeader = HashMapFactory.make();
+    // collect loop break and the jumps, key: loopBreaker,
     // value: the loops been jumped, not includes the inner loop, but includes the outer most loop
     HashMap<ISSABasicBlock, List<Loop>> jumpToOutside = HashMapFactory.make();
     // collect loop break and the jumps, key: loopBreaker,
@@ -465,7 +468,8 @@ public class LoopHelper {
     HashMap<ISSABasicBlock, List<Loop>> sharedLoopControl = HashMapFactory.make();
 
     // if there are only one loop, there wont be any nested loops
-    if (loops.size() < 2) return Arrays.asList(jumpToTop, jumpToOutside, sharedLoopControl);
+    if (loops.size() < 2)
+      return Arrays.asList(jumpToTop, jumpToOutside, sharedLoopControl, returnToParentHeader);
 
     // order loops by header from large to small
     List<Loop> sortedLoops =
@@ -539,13 +543,14 @@ public class LoopHelper {
                     .get(ll)
                     .getLoopControl()
                     .equals(ll.getLoopBreakerByExit(loopExit))
-                && ll.isLastBlockOfMiddlePart(ll.getLoopBreakerByExit(loopExit))) {
+                && childParentMap.get(ll).isLastBlockOfMiddlePart(loopExit)) {
               // there's a case where level 2 loop jump to the header of level 1 loop from loop
               // breaker which is other than loop control, then it
-              // should be part of jumpToTop
+              // should be similar to jumpToTop
               // create jump path from outer loop to inner loop
-              assert !jumpToTop.containsKey(ll.getLoopBreakerByExit(loopExit));
-              jumpToTop.put(ll.getLoopBreakerByExit(loopExit), Collections.singletonList(ll));
+              assert !returnToParentHeader.containsKey(ll.getLoopBreakerByExit(loopExit));
+              returnToParentHeader.put(
+                  ll.getLoopBreakerByExit(loopExit), Collections.singletonList(ll));
             }
           }
         });
@@ -553,6 +558,7 @@ public class LoopHelper {
     System.out.println("====loop jumps to top:\n" + jumpToTop);
     System.out.println("====loop jumps to outside:\n" + jumpToOutside);
     System.out.println("====loop shared control:\n" + sharedLoopControl);
-    return Arrays.asList(jumpToTop, jumpToOutside, sharedLoopControl);
+    System.out.println("====loop return to parent header from middle:\n" + returnToParentHeader);
+    return Arrays.asList(jumpToTop, jumpToOutside, sharedLoopControl, returnToParentHeader);
   }
 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -17,6 +17,7 @@ import com.ibm.wala.util.collections.IteratorUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -452,11 +453,15 @@ public class LoopHelper {
   }
 
   public static List<HashMap<ISSABasicBlock, List<Loop>>> updateLoopRelationship(
-      Map<ISSABasicBlock, Loop> loops) {
+      PrunedCFG<SSAInstruction, ISSABasicBlock> cfg, Map<ISSABasicBlock, Loop> loops) {
     // collect loop break and the jumps, key: loopBreaker,
     // value: the loops been jumped, not including the inner loop and outer loop
     HashMap<ISSABasicBlock, List<Loop>> jumpToTop = HashMapFactory.make();
+    // collect loop break and the jumps, key: loopBreaker,
+    // value: the loops been jumped, not includes the inner loop, but includes the outer most loop
     HashMap<ISSABasicBlock, List<Loop>> jumpToOutside = HashMapFactory.make();
+    // collect loop break and the jumps, key: loopBreaker,
+    // value: the nest loop hierarchy that share same loop control
     HashMap<ISSABasicBlock, List<Loop>> sharedLoopControl = HashMapFactory.make();
 
     // if there are only one loop, there wont be any nested loops
@@ -528,6 +533,19 @@ public class LoopHelper {
 
               System.out.println(
                   "This is an example of jump from inner loop to outer-most" + jumpPath);
+            } else if (cfg.getNormalSuccessors(loopExit)
+                    .contains(childParentMap.get(ll).getLoopHeader())
+                && !childParentMap
+                    .get(ll)
+                    .getLoopControl()
+                    .equals(ll.getLoopBreakerByExit(loopExit))
+                && ll.isLastBlockOfMiddlePart(ll.getLoopBreakerByExit(loopExit))) {
+              // there's a case where level 2 loop jump to the header of level 1 loop from loop
+              // breaker which is other than loop control, then it
+              // should be part of jumpToTop
+              // create jump path from outer loop to inner loop
+              assert !jumpToTop.containsKey(ll.getLoopBreakerByExit(loopExit));
+              jumpToTop.put(ll.getLoopBreakerByExit(loopExit), Collections.singletonList(ll));
             }
           }
         });


### PR DESCRIPTION
Changes made
1) Add returnToParentHeader to keep the list of backage from inner loop to its parent loop header, and set ctloopjump=1 for this case
2) Remove useless if test break after while(test) loop
3) Convert while(true) if test break else something into while(!test) something

Still have error in 2 sample for c2j but they succeeded in c2c