### PR TITLE
Re-work on feature 24: GOTO P-EXIT from nested inline PERFORM

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
@@ -147,7 +147,7 @@ public class CAstHelper {
             ast.makeConstant(varValue)));
   }
 
-  public static CAstNode generateInnerLoopJumpToHeader(
+  public static Pair<CAstNode, CAstNode> generateInnerLoopJumpToHeader(
       Map<ISSABasicBlock, List<Loop>> jumpToTop,
       Map<ISSABasicBlock, List<Loop>> returnToParentHeader,
       Loop currentLoop,
@@ -229,7 +229,7 @@ public class CAstHelper {
     }
 
     // if test has been changed then set loop type to be do while
-    return test;
+    return Pair.make(test, bodyNode);
   }
 
   public static CAstNode generateInnerLoopJumpToOutside(
@@ -303,9 +303,9 @@ public class CAstHelper {
                   ast.makeNode(CAstNode.VAR, ast.makeConstant(varName)),
                   ast.makeConstant(1)));
       // add it before break
-      if (nodeBlock.get(nodeBlock.size() - 1).getKind() == CAstNode.BREAK)
+      /*if (nodeBlock.get(nodeBlock.size() - 1).getKind() == CAstNode.BREAK)
         nodeBlock.add(nodeBlock.size() - 1, setTrue);
-      else nodeBlock.add(0, setTrue);
+      else*/ nodeBlock.add(0, setTrue);
     }
   }
 

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
@@ -303,9 +303,9 @@ public class CAstHelper {
                   ast.makeNode(CAstNode.VAR, ast.makeConstant(varName)),
                   ast.makeConstant(1)));
       // add it before break
-      /*if (nodeBlock.get(nodeBlock.size() - 1).getKind() == CAstNode.BREAK)
+      if (nodeBlock.get(nodeBlock.size() - 1).getKind() == CAstNode.BREAK)
         nodeBlock.add(nodeBlock.size() - 1, setTrue);
-      else*/ nodeBlock.add(0, setTrue);
+      else nodeBlock.add(0, setTrue);
     }
   }
 

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
@@ -188,6 +188,14 @@ public class Loop {
         .get();
   }
 
+  public ISSABasicBlock getLoopExitrByBreaker(ISSABasicBlock breaker) {
+    return loopBreakers.stream()
+        .filter(pair -> breaker.equals(pair.fst))
+        .map(pair -> pair.snd)
+        .findFirst()
+        .get();
+  }
+
   public boolean isLastBlockOfMiddlePart(ISSABasicBlock lastBlock) {
     if (parts.size() > 1) {
       List<ISSABasicBlock> allLastBlocks =

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
@@ -93,6 +93,16 @@ public class Loop {
             .flatMap(Collection::stream)
             .distinct()
             .collect(Collectors.toSet());
+    if (nestedLoops != null && nestedLoops.size() > 0) {
+      breakers.addAll(
+          nestedLoops.stream()
+              .map(loop -> loop.getLoopBreakersExits())
+              .flatMap(Collection::stream)
+              .distinct()
+              .collect(Collectors.toSet()));
+    }
+
+    // remove the breakers that's no longer as breaker
     Set<Pair<ISSABasicBlock, ISSABasicBlock>> shouldBeRemoved = HashSetFactory.make();
     breakers.forEach(
         pair -> {
@@ -197,7 +207,8 @@ public class Loop {
     return false;
   }
 
-  public boolean isExitOfNestedLoop(ISSABasicBlock loopBreaker) {
-    return nestedLoops.size()>0 && nestedLoops.stream().anyMatch(ll -> ll.getLoopExits().contains(loopBreaker));
+  public Set<Pair<ISSABasicBlock, ISSABasicBlock>> getLoopBreakersExits() {
+    assert (loopBreakers != null);
+    return loopBreakers;
   }
 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
@@ -196,4 +196,8 @@ public class Loop {
     }
     return false;
   }
+
+  public boolean isExitOfNestedLoop(ISSABasicBlock loopBreaker) {
+    return nestedLoops.size()>0 && nestedLoops.stream().anyMatch(ll -> ll.getLoopExits().contains(loopBreaker));
+  }
 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -561,8 +561,8 @@ public class LoopHelper {
                   sharedLoopControl.put(ll.getLoopBreakerByExit(loopExit), jumpPath);
                 } else if (!ll.getLoopControl().equals(ll.getLoopBreakerByExit(loopExit))) {
                   // jumpToOutside should not be the case of loop control
-                  assert !jumpToOutside.containsKey(ll.getLoopBreakerByExit(loopExit));
-                  jumpToOutside.put(ll.getLoopBreakerByExit(loopExit), jumpPath);
+                  if (!jumpToOutside.containsKey(ll.getLoopBreakerByExit(loopExit)))
+                    jumpToOutside.put(ll.getLoopBreakerByExit(loopExit), jumpPath);
                 }
               } else {
                 if (!jumpToTop.containsKey(ll.getLoopBreakerByExit(loopExit)))

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -537,7 +537,7 @@ public class LoopHelper {
 
               List<Loop> jumpPath = new ArrayList<>();
               jumpPath.add(ll);
-              
+
               // need to check more than 3 layer's loop
               while (!nextLoop.isLastBlock(loopBreaker)
                   && findNestedLoop(childParentMap, nextLoop, loopBreaker).isPresent()) {
@@ -642,12 +642,15 @@ public class LoopHelper {
     Collection<ISSABasicBlock> nextBBs = cfg.getNormalSuccessors(block);
     for (ISSABasicBlock next : nextBBs) {
       if (loop.getLoopHeader().equals(next)) {
-        continue;
+        result = true;
       } else if (loop.getAllBlocks().contains(next)) {
         result = gotoHeader(cfg, loop, next);
       } else {
         result = false;
       }
+
+      if (result) // found
+      break;
     }
     return result;
   }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -11,6 +11,7 @@ import com.ibm.wala.ssa.SSAPhiInstruction;
 import com.ibm.wala.ssa.SSAReturnInstruction;
 import com.ibm.wala.ssa.SSAUnaryOpInstruction;
 import com.ibm.wala.ssa.SSAUnspecifiedExprInstruction;
+import com.ibm.wala.ssa.SSAUnspecifiedInstruction;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.IteratorUtil;
@@ -125,6 +126,13 @@ public class LoopHelper {
             if (inst.iIndex() < 0) continue;
             // TODO: need to check if any other case should be placed here
             if (inst instanceof SSAReturnInstruction) {
+              continue;
+            }
+            if (inst instanceof SSAUnspecifiedInstruction
+                && ((SSAUnspecifiedInstruction<?>) inst).getPayload() != null
+                && "STOP RUN"
+                    .equalsIgnoreCase(
+                        ((SSAUnspecifiedInstruction<?>) inst).getPayload().toString())) {
               continue;
             }
             notWhileLoop = true;

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -557,12 +557,15 @@ public class LoopHelper {
               if (!childParentMap.containsKey(jumpPath.get(0))) {
                 // if the jumpPath includes top ones
                 if (jumpPath.get(0).getLoopControl().equals(ll.getLoopBreakerByExit(loopExit))) {
+                  assert !sharedLoopControl.containsKey(ll.getLoopBreakerByExit(loopExit));
                   sharedLoopControl.put(ll.getLoopBreakerByExit(loopExit), jumpPath);
                 } else {
+                  assert !jumpToOutside.containsKey(ll.getLoopBreakerByExit(loopExit));
                   jumpToOutside.put(ll.getLoopBreakerByExit(loopExit), jumpPath);
                 }
               } else {
-                jumpToTop.put(ll.getLoopBreakerByExit(loopExit), jumpPath);
+                if (!jumpToTop.containsKey(ll.getLoopBreakerByExit(loopExit)))
+                  jumpToTop.put(ll.getLoopBreakerByExit(loopExit), jumpPath);
               }
 
               System.out.println(

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -534,6 +534,10 @@ public class LoopHelper {
                 // TODO: need to check more than 3 layer's loop
                 ISSABasicBlock innerLoopBreak =
                     nestedLoop.get().getKey().getLoopBreakerByExit(loopBreaker);
+                if (nestedLoop.get().getKey().getLoopControl().equals(innerLoopBreak)) {
+                  // Skip loop control
+                  continue;
+                }
                 assert !returnToOutsideTail.containsKey(innerLoopBreak);
                 List<Loop> jumpPath = new ArrayList<>();
                 jumpPath.add(ll);

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -623,7 +623,7 @@ public class LoopHelper {
         jumpToTop, jumpToOutside, sharedLoopControl, returnToParentHeader, returnToOutsideTail);
   }
 
-  private static boolean gotoHeader(
+  public static boolean gotoHeader(
       PrunedCFG<SSAInstruction, ISSABasicBlock> cfg, Loop loop, ISSABasicBlock block) {
     // check if all branches will goto loop header
     boolean result = true;

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -559,7 +559,8 @@ public class LoopHelper {
                 if (jumpPath.get(0).getLoopControl().equals(ll.getLoopBreakerByExit(loopExit))) {
                   assert !sharedLoopControl.containsKey(ll.getLoopBreakerByExit(loopExit));
                   sharedLoopControl.put(ll.getLoopBreakerByExit(loopExit), jumpPath);
-                } else {
+                } else if (!ll.getLoopControl().equals(ll.getLoopBreakerByExit(loopExit))) {
+                  // jumpToOutside should not be the case of loop control
                   assert !jumpToOutside.containsKey(ll.getLoopBreakerByExit(loopExit));
                   jumpToOutside.put(ll.getLoopBreakerByExit(loopExit), jumpPath);
                 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1793,12 +1793,15 @@ public abstract class ToSource {
       }
 
       Pair<CAstNode, CAstNode> newNodeByJump =
-          CAstHelper.generateInnerLoopJumpToHeader(
+          CAstHelper.generateInnerLoopJumpToHeaderOrTail(
               jumpToTop,
               returnToParentHeader,
+              jumpToOutside,
+              returnToOutsideTail,
               currentLoop,
               bodyNode,
               CT_LOOP_JUMP_VAR_NAME,
+              CT_LOOP_BREAK_VAR_NAME,
               loopType,
               test);
       if (!test.equals(newNodeByJump.fst)) {
@@ -1807,10 +1810,6 @@ public abstract class ToSource {
         loopType = LoopType.DOWHILE;
       }
       bodyNode = newNodeByJump.snd;
-
-      bodyNode =
-          CAstHelper.generateInnerLoopJumpToOutside(
-              jumpToOutside, returnToOutsideTail, currentLoop, bodyNode, CT_LOOP_BREAK_VAR_NAME);
 
       CAstNode loopNode =
           ast.makeNode(

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1628,7 +1628,9 @@ public abstract class ToSource {
         condSuccessor = lr.toCAst(currentLoops);
       }
 
-      if (after != null) {
+      if (after != null
+          && !(sharedLoopControl.containsKey(currentLoop.getLoopControl())
+              && sharedLoopControl.get(currentLoop.getLoopControl()).get(0).equals(currentLoop))) {
         RegionTreeNode rt = children.get(instruction).get(after);
         afterNodes.addAll(rt.toCAst(currentLoops).getChildren());
       }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1785,7 +1785,7 @@ public abstract class ToSource {
                 condSuccessor.getChildren().toArray(new CAstNode[condSuccessor.getChildCount()]));
       }
 
-      CAstNode newTestByJump =
+      Pair<CAstNode, CAstNode> newNodeByJump =
           CAstHelper.generateInnerLoopJumpToHeader(
               jumpToTop,
               returnToParentHeader,
@@ -1794,11 +1794,12 @@ public abstract class ToSource {
               CT_LOOP_JUMP_VAR_NAME,
               loopType,
               test);
-      if (!test.equals(newTestByJump)) {
+      if (!test.equals(newNodeByJump.fst)) {
         // there's only one case of changing test, which will lead to change loop type
-        test = newTestByJump;
+        test = newNodeByJump.fst;
         loopType = LoopType.DOWHILE;
       }
+      bodyNode = newNodeByJump.snd;
 
       bodyNode =
           CAstHelper.generateInnerLoopJumpToOutside(


### PR DESCRIPTION
A new helper variable will be used: ctloopbreak.

Added several samples for
1) more than 3 layers of loops
2) Mixed goto counter and goto counter-exit from different level of loops

All C2C pass, some C2J failed might be caused by phi nodes which wont be fixed for now.