### PR TITLE
Updates on IF/EXIT PARAGRAPH and the check of FOR-LOOP

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
@@ -15,8 +15,8 @@ import java.util.Map;
 /** The helper class for some methods of loop */
 public class CAstHelper {
   private static final CAst ast = new CAstImpl();
-  
-//hard code the conditional statements for now
+
+  // hard code the conditional statements for now
   private static final String[] supportedStatements =
       new String[] {
         "ADD",
@@ -580,5 +580,15 @@ public class CAstHelper {
       if (assignNode != null) break;
     }
     return assignNode;
+  }
+
+  public static CAstNode createExitParagraph() {
+    // If goto instruction will go to -1 that should be an EXIT PARAGRAPGH
+    return ast.makeNode(
+        CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.GOTO, ast.makeConstant("EXIT PARAGRAPH")));
+    // List<CAstNode> args = new ArrayList<>();
+    // args.add(ast.makeConstant("EXIT PARAGRAPH"));
+    // return ast.makeNode(CAstNode.PRIMITIVE, args.toArray(new
+    // CAstNode[args.size()]));
   }
 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
@@ -5,15 +5,11 @@ import com.ibm.wala.cast.tree.CAstNode;
 import com.ibm.wala.cast.tree.impl.CAstImpl;
 import com.ibm.wala.cast.tree.impl.CAstOperator;
 import com.ibm.wala.cast.util.CAstPattern;
-import com.ibm.wala.ipa.cfg.PrunedCFG;
 import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.ssa.SSACFG.BasicBlock;
 import com.ibm.wala.ssa.SSAGotoInstruction;
-import com.ibm.wala.ssa.SSAInstruction;
-import com.ibm.wala.ssa.SSAReturnInstruction;
 import com.ibm.wala.util.collections.Pair;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -587,31 +583,34 @@ public class CAstHelper {
     return assignNode;
   }
 
-  public static boolean needsExitParagraph(
-      SSAGotoInstruction inst, PrunedCFG<SSAInstruction, ISSABasicBlock> cfg) {
+  public static boolean needsExitParagraph(SSAGotoInstruction inst) {
     // check if it's a jump from middle to the end
     if (inst.getTarget() == -1) {
       // goto -1 means EXIT PARAGRAPH
       return true;
     }
+    return false;
 
-    if ((inst.iIndex() + 1) == inst.getTarget()) {
-      // goto next instruction then ignore this goto
-      return false;
-    }
-
-    ISSABasicBlock targetBlock = cfg.getBlockForInstruction(inst.getTarget());
-    Collection<ISSABasicBlock> succBlock =
-        cfg.getNormalSuccessors(cfg.getBlockForInstruction(inst.iIndex()));
-    if (succBlock.size() == 1
-        && succBlock.iterator().next().equals(targetBlock)
-        && targetBlock.getFirstInstructionIndex() == targetBlock.getLastInstructionIndex()
-        && targetBlock.getLastInstruction() instanceof SSAReturnInstruction) {
-      // skip the case where it'll move on to RETURN
-      return false;
-    }
-    return targetBlock.getLastInstructionIndex() == inst.getTarget()
-        && targetBlock.getLastInstruction() instanceof SSAReturnInstruction;
+    // TODO: I though there are other cases that EXIT PARAGRAPH should be needed but test result
+    // shows that these conditionals are not needed. I'll keep them as comment for now in case if
+    // needed in future
+    //    if ((inst.iIndex() + 1) == inst.getTarget()) {
+    //      // goto next instruction then ignore this goto
+    //      return false;
+    //    }
+    //
+    //    ISSABasicBlock targetBlock = cfg.getBlockForInstruction(inst.getTarget());
+    //    Collection<ISSABasicBlock> succBlock =
+    //        cfg.getNormalSuccessors(cfg.getBlockForInstruction(inst.iIndex()));
+    //    if (succBlock.size() == 1
+    //        && succBlock.iterator().next().equals(targetBlock)
+    //        && targetBlock.getFirstInstructionIndex() == targetBlock.getLastInstructionIndex()
+    //        && targetBlock.getLastInstruction() instanceof SSAReturnInstruction) {
+    //      // skip the case where it'll move on to RETURN
+    //      return false;
+    //    }
+    //    return targetBlock.getLastInstructionIndex() == inst.getTarget()
+    //        && targetBlock.getLastInstruction() instanceof SSAReturnInstruction;
   }
 
   public static CAstNode createExitParagraph() {

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
@@ -5,10 +5,15 @@ import com.ibm.wala.cast.tree.CAstNode;
 import com.ibm.wala.cast.tree.impl.CAstImpl;
 import com.ibm.wala.cast.tree.impl.CAstOperator;
 import com.ibm.wala.cast.util.CAstPattern;
+import com.ibm.wala.ipa.cfg.PrunedCFG;
 import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.ssa.SSACFG.BasicBlock;
+import com.ibm.wala.ssa.SSAGotoInstruction;
+import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SSAReturnInstruction;
 import com.ibm.wala.util.collections.Pair;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -580,6 +585,33 @@ public class CAstHelper {
       if (assignNode != null) break;
     }
     return assignNode;
+  }
+
+  public static boolean needsExitParagraph(
+      SSAGotoInstruction inst, PrunedCFG<SSAInstruction, ISSABasicBlock> cfg) {
+    // check if it's a jump from middle to the end
+    if (inst.getTarget() == -1) {
+      // goto -1 means EXIT PARAGRAPH
+      return true;
+    }
+
+    if ((inst.iIndex() + 1) == inst.getTarget()) {
+      // goto next instruction then ignore this goto
+      return false;
+    }
+
+    ISSABasicBlock targetBlock = cfg.getBlockForInstruction(inst.getTarget());
+    Collection<ISSABasicBlock> succBlock =
+        cfg.getNormalSuccessors(cfg.getBlockForInstruction(inst.iIndex()));
+    if (succBlock.size() == 1
+        && succBlock.iterator().next().equals(targetBlock)
+        && targetBlock.getFirstInstructionIndex() == targetBlock.getLastInstructionIndex()
+        && targetBlock.getLastInstruction() instanceof SSAReturnInstruction) {
+      // skip the case where it'll move on to RETURN
+      return false;
+    }
+    return targetBlock.getLastInstructionIndex() == inst.getTarget()
+        && targetBlock.getLastInstruction() instanceof SSAReturnInstruction;
   }
 
   public static CAstNode createExitParagraph() {

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -40,8 +40,18 @@ public class LoopHelper {
     Set<ISSABasicBlock> breakers = loop.getLoopBreakers();
     Optional<ISSABasicBlock> key =
         breakers.stream().filter(bb -> jumpToTop.containsKey(bb)).findFirst();
-    if (!key.isPresent()) // if cannot find it then it wont be a for loop
-    return false;
+    if (!key.isPresent()) { // if cannot find it then it might not be a for loop
+      int totalBreakers = breakers.size();
+      SSAInstruction ii = null;
+      for (ISSABasicBlock bb : breakers) {
+        ii = loop.getLoopExitrByBreaker(bb).getLastInstruction();
+        if (ii instanceof SSAGotoInstruction && ((SSAGotoInstruction) ii).getTarget() == -1)
+          totalBreakers--;
+      }
+      if (totalBreakers == 1) // other breakers ended with termination
+      return true;
+      return false;
+    }
 
     // check if the other loop exit is the last block of the parent loop
     return breakers.stream()

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -2309,7 +2309,16 @@ public abstract class ToSource {
           } else if (loop != null && loop.getLoopExits().containsAll(cfg.getNormalSuccessors(bb))) {
             node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.BREAK));
           } else {
-            node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.GOTO));
+            if (inst.getTarget() == -1) {
+              node = CAstHelper.createExitParagraph();
+            } else if (cfg.getBlockForInstruction(inst.getTarget()).getLastInstructionIndex()
+                    == inst.getTarget()
+                && cfg.getBlockForInstruction(inst.getTarget()).getLastInstruction()
+                    instanceof SSAReturnInstruction
+                && (inst.iIndex() + 1) != inst.getTarget()) {
+              // if it's a jump from middle to the end
+              node = CAstHelper.createExitParagraph();
+            } else node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.GOTO));
           }
           markPosition(node, inst.iIndex());
         }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -2308,18 +2308,10 @@ public abstract class ToSource {
             node = ast.makeNode(CAstNode.CONTINUE);
           } else if (loop != null && loop.getLoopExits().containsAll(cfg.getNormalSuccessors(bb))) {
             node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.BREAK));
-          } else {
-            if (inst.getTarget() == -1) {
-              node = CAstHelper.createExitParagraph();
-            } else if (cfg.getBlockForInstruction(inst.getTarget()).getLastInstructionIndex()
-                    == inst.getTarget()
-                && cfg.getBlockForInstruction(inst.getTarget()).getLastInstruction()
-                    instanceof SSAReturnInstruction
-                && (inst.iIndex() + 1) != inst.getTarget()) {
-              // if it's a jump from middle to the end
-              node = CAstHelper.createExitParagraph();
-            } else node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.GOTO));
-          }
+          } else if (CAstHelper.needsExitParagraph(inst, cfg)) {
+            // if it's a jump from middle to the end
+            node = CAstHelper.createExitParagraph();
+          } else node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.GOTO));
           markPosition(node, inst.iIndex());
         }
 

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1740,7 +1740,7 @@ public abstract class ToSource {
             }
           } else afterNodes.add(ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.BREAK)));
 
-          CAstNode ifStmt =
+          List<CAstNode> ifStmt =
               CAstHelper.makeIfStmt(
                   ast.makeNode(CAstNode.UNARY_EXPR, CAstOperator.OP_NOT, test),
                   // include the nodes in the else branch
@@ -1752,8 +1752,9 @@ public abstract class ToSource {
                               CAstNode.BLOCK_STMT,
                               afterNodes.toArray(new CAstNode[afterNodes.size()]))),
                   // it should be a block instead of array of AST nodes
-                  condSuccessor);
-          nodesBeforeControl.add(ifStmt);
+                  condSuccessor,
+                  true);
+          nodesBeforeControl.addAll(ifStmt);
           bodyNode =
               ast.makeNode(
                   CAstNode.BLOCK_STMT,
@@ -2784,7 +2785,12 @@ public abstract class ToSource {
           takenStmt = checkLinePhi(takenStmt, instruction, taken);
 
           if (takenStmt != null) {
-            node = CAstHelper.makeIfStmt(test, takenStmt, notTakenStmt);
+            List<CAstNode> ifStmt =
+                CAstHelper.makeIfStmt(test, takenStmt, notTakenStmt, loop != null);
+            if (ifStmt.size() == 1) node = ifStmt.get(0);
+            else {
+              node = ast.makeNode(CAstNode.BLOCK_STMT, ifStmt);
+            }
           } else {
             node =
                 CAstHelper.makeIfStmt(

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -2308,7 +2308,7 @@ public abstract class ToSource {
             node = ast.makeNode(CAstNode.CONTINUE);
           } else if (loop != null && loop.getLoopExits().containsAll(cfg.getNormalSuccessors(bb))) {
             node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.BREAK));
-          } else if (CAstHelper.needsExitParagraph(inst, cfg)) {
+          } else if (CAstHelper.needsExitParagraph(inst)) {
             // if it's a jump from middle to the end
             node = CAstHelper.createExitParagraph();
           } else node = ast.makeNode(CAstNode.BLOCK_STMT, ast.makeNode(CAstNode.GOTO));


### PR DESCRIPTION
This pr will 
1) Change IF CAst node to reduce if-else in loops.
  a) Only applies to the IF in a loop
  b) When there's a break in then branch, then move else branch after the IF
  c) When there's a break in else branch, then negation the test and move the then branch after the IF
2) No change to conditional statements.
3) Update the check for FOR-LOOP to recognize the case of perform-inline-loop-2 as a FOR loop instead of flexible loop
4) Generate EXIT PARAGRAPH as a child of GOTO in the cases of
  a) GOTO -1
  b) GOTO the end of paragraph (RETURN) from the middle of the paragraph