### PR TITLE
Fix a small issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ JavaVersion.current().let {
 
 group = name
 
-version = "1.1.0-rc1"
+version = "1.6.8-SNAPSHOT"
 
 // version of Eclipse JARs to use for Eclipse-integrated WALA components.
 val eclipseVersion: EclipseRelease by extra {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ JavaVersion.current().let {
 
 group = name
 
-version = "1.6.8-SNAPSHOT"
+version = "1.1.0-rc1"
 
 // version of Eclipse JARs to use for Eclipse-integrated WALA components.
 val eclipseVersion: EclipseRelease by extra {

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/LoopHelper.java
@@ -379,6 +379,11 @@ public class LoopHelper {
       }
     } else {
       if (isAssignment(chunk)) {
+        // if it is assignment, for perf-with-goto-6-6.cbl, it should be in outer loop but not in
+        // inner loop
+        // this is a temp solution as we can't tell other clue to make it happen
+        if (containsInNestedLoop(loop, loops, currentBB)) return true;
+
         // if it is loop control, assignment should be ignored
         // except the last assignment for for-loop
         if (chunk.size() == 1


### PR DESCRIPTION
This is the fix for perf-with-goto-6-6.cbl where the assignment was created before the outer-most loop. It should be placed within the outer-most loop and before inner loop.