### PR TITLE
Fix the case when a loop has no control

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/Loop.java
@@ -34,6 +34,8 @@ public class Loop {
    */
   private Set<Pair<ISSABasicBlock, ISSABasicBlock>> loopBreakers;
 
+  private boolean hasLoopControl = true;
+
   public Loop(ISSABasicBlock header) {
     assert (header != null);
     this.loopHeader = header;
@@ -219,5 +221,13 @@ public class Loop {
   public Set<Pair<ISSABasicBlock, ISSABasicBlock>> getLoopBreakersExits() {
     assert (loopBreakers != null);
     return loopBreakers;
+  }
+
+  public boolean isHasLoopControl() {
+    return hasLoopControl;
+  }
+
+  public void setHasLoopControl(boolean hasLoopControl) {
+    this.hasLoopControl = hasLoopControl;
   }
 }


### PR DESCRIPTION
When two loop parts merged together, there's a case where loop control can not be found. This is temporary solution for the case where a flexible loop will be created.