### PR TITLE
Support more than one CAst Nodes that's the same at then and else branch

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
@@ -191,18 +191,24 @@ public class CAstHelper {
     // remove GOTO as the last one in the list
     // GOTO with a label should be kept in the list
     List<CAstNode> result = new ArrayList<>();
-
+    int lastIndex = originalList.size() - 1;
     for (int i = originalList.size() - 1; i >= 0; i--) {
       // ignore GOTO in BLOCK
       if (originalList.get(i).getKind() == CAstNode.BLOCK_STMT
           && originalList.get(i).getChildCount() == 1
           && originalList.get(i).getChild(0).getKind() == CAstNode.GOTO
-          && originalList.get(i).getChild(0).getChildCount() == 0) continue;
+          && originalList.get(i).getChild(0).getChildCount() == 0) {
+        lastIndex--;
+        continue;
+      }
       // ignore GOTO or EMPTY
       if ((originalList.get(i).getKind() == CAstNode.GOTO
               && originalList.get(i).getChildCount() == 0)
-          || originalList.get(i).getKind() == CAstNode.EMPTY) continue;
-      if (i == originalList.size() - 1
+          || originalList.get(i).getKind() == CAstNode.EMPTY) {
+        lastIndex--;
+        continue;
+      }
+      if (i == lastIndex
           && originalList.get(i).getKind() == CAstNode.BLOCK_STMT
           && originalList.get(i).getChildCount() > 0) {
         // ignore GOTO in nested block

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
@@ -120,15 +120,24 @@ public class CAstHelper {
                   CAstNode.IF_STMT, newTest, ast.makeNode(CAstNode.BLOCK_STMT, elseBranchList)));
         }
         result.addAll(commonTail);
-      } else if (shouldOnlyUseOneBranch(thenBranchList, inLoop)
-          && !shouldOnlyUseOneBranch(elseBranchList, inLoop)) {
+      } else if (thenBranchList.size() > 0
+          && endingWithTermination(thenBranchList.get(thenBranchList.size() - 1))
+          && elseBranchList.size() > 0
+          && endingWithTermination(elseBranchList.get(elseBranchList.size() - 1))) {
+        // this is the special case where we want to keep if and else
+        result.add(
+            ast.makeNode(
+                CAstNode.IF_STMT,
+                newTest,
+                ast.makeNode(CAstNode.BLOCK_STMT, thenBranchList),
+                ast.makeNode(CAstNode.BLOCK_STMT, elseBranchList)));
+      } else if (shouldOnlyUseOneBranch(thenBranchList, inLoop)) {
         // if then branch is ended with break/continue/termination, then move else after the if
         result.add(
             ast.makeNode(
                 CAstNode.IF_STMT, newTest, ast.makeNode(CAstNode.BLOCK_STMT, thenBranchList)));
         result.addAll(elseBranchList);
-      } else if (shouldOnlyUseOneBranch(elseBranchList, inLoop)
-          && !shouldOnlyUseOneBranch(thenBranchList, inLoop)) {
+      } else if (shouldOnlyUseOneBranch(elseBranchList, inLoop)) {
         // Negation the test if else branch is ended with break/continue/termination
         if (isLeadingNegation(newTest)) {
           newTest = stableRemoveLeadingNegation(newTest);

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/CAstHelper.java
@@ -8,12 +8,11 @@ import com.ibm.wala.cast.util.CAstPattern;
 import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.ssa.SSACFG.BasicBlock;
 import com.ibm.wala.ssa.SSAGotoInstruction;
-import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.Pair;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /** The helper class for some methods of loop */
 public class CAstHelper {
@@ -106,7 +105,7 @@ public class CAstHelper {
                         && elseBranch.getChild(0).getKind() == CAstNode.BLOCK_STMT)
                     ? elseBranch.getChild(0).getChildren()
                     : elseBranch.getChildren());
-        Set<CAstNode> commonTail = gatherCommonTail(thenBranchList, elseBranchList);
+        List<CAstNode> commonTail = gatherCommonTail(thenBranchList, elseBranchList);
         if (commonTail.isEmpty()) {
           result.add(ast.makeNode(CAstNode.IF_STMT, newTest, thenBranch, elseBranch));
         } else {
@@ -180,8 +179,9 @@ public class CAstHelper {
     return originalStr.substring(originalStr.indexOf(":") + 1);
   }
 
-  private static Set<CAstNode> gatherCommonTail(List<CAstNode> first, List<CAstNode> second) {
-    Map<CAstNode, CAstNode> result = HashMapFactory.make();
+  private static List<CAstNode> gatherCommonTail(List<CAstNode> first, List<CAstNode> second) {
+    List<CAstNode> commonInFirst = new ArrayList<>();
+    List<CAstNode> commonInSecond = new ArrayList<>();
     String firstStr = null;
     String secondStr = null;
     for (int i = first.size() - 1, j = second.size() - 1; i >= 0 && j >= 0; ) {
@@ -189,15 +189,16 @@ public class CAstHelper {
       secondStr = trimCAstNodeString(second.get(j).toString());
 
       if (firstStr.equals(secondStr)) {
-        result.put(first.get(i), second.get(j));
+        commonInFirst.add(first.get(i));
+        commonInSecond.add(second.get(j));
         i--;
         j--;
-      }
-      break;
+      } else break;
     }
-    first.removeAll(result.keySet());
-    second.removeAll(result.values());
-    return result.keySet();
+    Collections.reverse(commonInFirst);
+    first.removeAll(commonInFirst);
+    second.removeAll(commonInSecond);
+    return commonInFirst;
   }
 
   public static boolean isConditionalStatement(CAstNode test) {

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -1567,10 +1567,8 @@ public abstract class ToSource {
       elts.add(stuff.fst);
       decls.addAll(stuff.snd);
 
-      CAstNode bodyNode = ast.makeNode(CAstNode.BLOCK_STMT, stuff.fst.getChildren());
-
       CAstNode loopNode =
-          ast.makeNode(CAstNode.LOOP, ast.makeConstant(true), bodyNode, ast.makeConstant(false));
+          ast.makeNode(CAstNode.LOOP, ast.makeConstant(true), stuff.fst, ast.makeConstant(false));
       return Pair.make(ast.makeNode(CAstNode.BLOCK_STMT, loopNode), decls);
     }
 
@@ -1750,7 +1748,7 @@ public abstract class ToSource {
           loopType = LoopType.WHILE;
         } else {
           if (afterNodes.size() > 0) {
-            if (CAstHelper.endingWithBreak(afterNodes.get(afterNodes.size() - 1))
+            if (CAstHelper.endingWithBreakOrContinue(afterNodes.get(afterNodes.size() - 1))
                 || CAstHelper.endingWithTermination(afterNodes.get(afterNodes.size() - 1))) {
               if (DEBUG)
                 System.err.println(
@@ -2774,7 +2772,7 @@ public abstract class ToSource {
                 // when there are two goto instruction, the second from last will be the break
                 lastNode = notTakenBlock.get(notTakenBlock.size() - 2);
               }
-              if (CAstHelper.endingWithBreak(lastNode)
+              if (CAstHelper.endingWithBreakOrContinue(lastNode)
                   || CAstHelper.endingWithTermination(lastNode)) {
                 if (DEBUG)
                   System.err.println(
@@ -2807,7 +2805,7 @@ public abstract class ToSource {
               if (takenBlock == null) {
                 takenBlock = new ArrayList<>();
                 takenBlock.add(ast.makeNode(CAstNode.BREAK));
-              } else if (CAstHelper.endingWithBreak(takenBlock.get(takenBlock.size() - 1))
+              } else if (CAstHelper.endingWithBreakOrContinue(takenBlock.get(takenBlock.size() - 1))
                   || CAstHelper.endingWithTermination(takenBlock.get(takenBlock.size() - 1))) {
                 if (DEBUG)
                   System.err.println(


### PR DESCRIPTION
The original implementation only support one CAst node that's the same in both branches as the last node.
This change will support more than 1.