### PR TITLE
Fix the issue by lookup name by def

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -744,7 +744,8 @@ public abstract class ToSource {
       } else {
         for (int i = 1; i <= ir.getSymbolTable().getMaxValueNumber(); i++) {
           if (mergePhis.find(i) == root_vn) {
-            // since some exprs are created as unspecified, thus sometimes there'll be 0 use
+            // since some exprs are created as unspecified, sometimes there'll be 0 uses which is
+            // not true
             // in this case, need to check def as well
             String localName = null;
             for (Iterator<SSAInstruction> uses = du.getUses(i); uses.hasNext(); ) {
@@ -757,7 +758,7 @@ public abstract class ToSource {
               }
             }
 
-            if (localName == null) {
+            if (du.getNumberOfUses(i) == 0) {
               // try to find local name by def
               SSAInstruction uv = du.getDef(i);
               if (uv != null && uv.iIndex() >= 0) {

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -744,15 +744,31 @@ public abstract class ToSource {
       } else {
         for (int i = 1; i <= ir.getSymbolTable().getMaxValueNumber(); i++) {
           if (mergePhis.find(i) == root_vn) {
+            // since some exprs are created as unspecified, thus sometimes there'll be 0 use
+            // in this case, need to check def as well
+            String localName = null;
             for (Iterator<SSAInstruction> uses = du.getUses(i); uses.hasNext(); ) {
               SSAInstruction uv = uses.next();
               if (uv.iIndex() >= 0) {
                 String[] names = ir.getLocalNames(uv.iIndex(), i);
                 if (names != null && names.length > 0) {
-                  name = names[0];
+                  localName = names[0];
                 }
               }
             }
+
+            if (localName == null) {
+              // try to find local name by def
+              SSAInstruction uv = du.getDef(i);
+              if (uv != null && uv.iIndex() >= 0) {
+                String[] names = ir.getLocalNames(uv.iIndex(), i);
+                if (names != null && names.length > 0) {
+                  localName = names[0];
+                }
+              }
+            }
+
+            if (localName != null) name = localName;
           }
         }
         return name;


### PR DESCRIPTION
There's a case where a block which is assignment, will be split as unstructured code. At that time the variable `j` will be lost. the default variable name `var` will be used, which is wrong.
With the change, the issue is fixed