### PR TITLE
move implicit scanner to a field, and have only 1

### DIFF
--- a/cast/java/src/main/java/com/ibm/wala/cast/java/toSource/ToSourceFromJava.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/toSource/ToSourceFromJava.java
@@ -177,6 +177,19 @@ public class ToSourceFromJava extends ToSource {
                         + " "
                         + nameToJava(fr.getName().toString(), false)
                         + ";");
+                Pair<String, String> key =
+                    Pair.make(
+                        fr.getFieldTypeReference()
+                            .getName()
+                            .getPackage()
+                            .toString()
+                            .replace('/', '.'),
+                        fr.getFieldTypeReference().getName().getClassName().toString());
+                if (!seen.contains(key)) {
+                  seen.add(key);
+                  String importStr = "import " + key.fst + "." + nameToJava(key.snd, true);
+                  all.println(importStr + (importStr.endsWith(";") ? "" : ";"));
+                }
               }
               for (IField fr : cls.getDeclaredInstanceFields()) {
                 out.println(

--- a/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/toSource/ToSource.java
@@ -3044,11 +3044,15 @@ public abstract class ToSource {
                   CAstNode.OBJECT_REF,
                   instruction.isStatic()
                       ? ast.makeConstant(
-                          instruction
-                              .getDeclaredField()
-                              .getDeclaringClass()
-                              .getName()
-                              .getClassName())
+                          Atom.findOrCreateUnicodeAtom(
+                              nameToJava(
+                                  instruction
+                                      .getDeclaredField()
+                                      .getDeclaringClass()
+                                      .getName()
+                                      .getClassName()
+                                      .toString(),
+                                  true)))
                       : visit(instruction.getRef()),
                   ast.makeConstant(instruction.getDeclaredField()));
           markPosition(node, instruction.iIndex());
@@ -3056,6 +3060,7 @@ public abstract class ToSource {
 
         @Override
         public void visitPut(SSAPutInstruction instruction) {
+          recordPackage(instruction.getDeclaredFieldType());
           if (instruction.isStatic()) {
             node =
                 ast.makeNode(
@@ -3065,11 +3070,15 @@ public abstract class ToSource {
                         ast.makeNode(
                             CAstNode.OBJECT_REF,
                             ast.makeConstant(
-                                instruction
-                                    .getDeclaredField()
-                                    .getDeclaringClass()
-                                    .getName()
-                                    .getClassName()),
+                                Atom.findOrCreateUnicodeAtom(
+                                    nameToJava(
+                                        instruction
+                                            .getDeclaredField()
+                                            .getDeclaringClass()
+                                            .getName()
+                                            .getClassName()
+                                            .toString(),
+                                        true))),
                             ast.makeConstant(instruction.getDeclaredField())),
                         visit(instruction.getVal())));
           } else {
@@ -3354,6 +3363,7 @@ public abstract class ToSource {
     protected boolean visitBlockStmt(
         CAstNode n, CodeGenerationContext c, CAstVisitor<CodeGenerationContext> visitor) {
       CodeGenerationContext cc = c.nonTopLevel();
+
       try (ByteArrayOutputStream b = new ByteArrayOutputStream()) {
         try (PrintWriter bw = new PrintWriter(b)) {
 
@@ -3668,6 +3678,8 @@ public abstract class ToSource {
 
         } else {
           ToJavaVisitor cif = makeToJavaVisitor(ir, out, indent + 1, varTypes);
+          indent();
+          out.println("boolean junkForSideEffects = ");
           cif.visit(n.getChild(0), c, cif);
           out.println(";");
         }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -2638,10 +2638,10 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     Scope getGlobalScope();
   }
 
-  private abstract class DelegatingContext implements WalkContext {
+  public abstract class DelegatingContext implements WalkContext {
     private final WalkContext parent;
 
-    DelegatingContext(WalkContext parent) {
+    protected DelegatingContext(WalkContext parent) {
       this.parent = parent;
     }
 


### PR DESCRIPTION
fixes to make the implicit scanner a single field in the main program, needed to stop multiple scanners from eating each others' input.